### PR TITLE
fix: Copy index.html into 404.html in build folder

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -15,6 +15,7 @@ jobs:
         run: |
           npm install
           npm run build
+          cp dist/documentation/index.html dist/documentation/404.html  
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:


### PR DESCRIPTION
By copying index.html into 404.html, URLs pointing to Angular-controlled paths will still work as opposed to it currently throwing 404s.

Signed-off-by: Josh Kim <kjosh@vmware.com>